### PR TITLE
Use inputstream.adaptive for HLS playback

### DIFF
--- a/plugin.video.dropout/addon.xml
+++ b/plugin.video.dropout/addon.xml
@@ -10,7 +10,7 @@
 		<import addon="xbmc.addon" version="20.90.101" />
 		<import addon="script.module.beautifulsoup4" version="4.12.2" />
 		<import addon="script.module.requests" version="2.31.0" />
-		<import addon="inputstream.adaptive" version="21.5.13" />
+		<import addon="inputstream.adaptive" version="21.0.0" optional="true" />
 	</requires>
 	<extension point="xbmc.python.pluginsource" library="entry.py" provides="video">
 		<provides>video</provides>

--- a/plugin.video.dropout/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.dropout/resources/language/resource.language.en_gb/strings.po
@@ -26,6 +26,10 @@ msgctxt "#32003"
 msgid "Debug Mode"
 msgstr ""
 
+msgctxt "#32004"
+msgid "Use InputStream Adaptive"
+msgstr ""
+
 msgctxt "#32010"
 msgid "General"
 msgstr ""
@@ -40,6 +44,10 @@ msgstr ""
 
 msgctxt "#32013"
 msgid "Debugging"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Playback"
 msgstr ""
 
 msgctxt "#32101"

--- a/plugin.video.dropout/resources/lib/addon.py
+++ b/plugin.video.dropout/resources/lib/addon.py
@@ -40,7 +40,18 @@ class Addon:
 
     @classmethod
     def use_inputstream_adaptive(cls) -> bool:
-        return cls.XBMC.getSettings().getBool("use_inputstream_adaptive")
+        return (
+            cls.XBMC.getSettings().getBool("use_inputstream_adaptive")
+            and cls.is_inputstream_adaptive_available()
+        )
+
+    @classmethod
+    def is_inputstream_adaptive_available(cls) -> bool:
+        try:
+            addon = xbmcaddon.Addon("inputstream.adaptive")
+            return addon is not None
+        except RuntimeError:
+            return False
 
     @classmethod
     def settings(cls) -> Settings:

--- a/plugin.video.dropout/resources/lib/addon.py
+++ b/plugin.video.dropout/resources/lib/addon.py
@@ -39,5 +39,9 @@ class Addon:
         cls.XBMC.setSetting("password", "")
 
     @classmethod
+    def use_inputstream_adaptive(cls) -> bool:
+        return cls.XBMC.getSettings().getBool("use_inputstream_adaptive")
+
+    @classmethod
     def settings(cls) -> Settings:
         return Settings()

--- a/plugin.video.dropout/resources/lib/ui.py
+++ b/plugin.video.dropout/resources/lib/ui.py
@@ -521,4 +521,5 @@ def play_video(router: Router, media: Playable, data: VideoData) -> None:
     li = Folder.info_for_playable(router=router, video=media, path=data.url)
     li.setMimeType(data.mime_type)
     li.setSubtitles(data.subtitles)
+    li.setProperty("inputstream", "inputstream.adaptive")
     xbmcplugin.setResolvedUrl(Addon.handle(), succeeded=True, listitem=li)

--- a/plugin.video.dropout/resources/lib/ui.py
+++ b/plugin.video.dropout/resources/lib/ui.py
@@ -520,6 +520,8 @@ def notify(message: int, *, time: int) -> None:
 def play_video(router: Router, media: Playable, data: VideoData) -> None:
     li = Folder.info_for_playable(router=router, video=media, path=data.url)
     li.setMimeType(data.mime_type)
+    li.setContentLookup(False)
     li.setSubtitles(data.subtitles)
-    li.setProperty("inputstream", "inputstream.adaptive")
+    if Addon.use_inputstream_adaptive():
+        li.setProperty("inputstream", "inputstream.adaptive")
     xbmcplugin.setResolvedUrl(Addon.handle(), succeeded=True, listitem=li)

--- a/plugin.video.dropout/resources/settings.xml
+++ b/plugin.video.dropout/resources/settings.xml
@@ -2,13 +2,14 @@
 <settings version="1">
 	<section id="plugin.video.dropout">
 		<category id="general" label="32010" help="">
-			<group id="authentication" label="32011">
-				<!-- FIXME: Dummy to grab initial focus -->
-				<setting id="dummy" type="boolean" label=" " help="">
+			<group id="playback" label="32014">
+				<setting id="use_inputstream_adaptive" type="boolean" label="32004" help="">
 					<level>0</level>
 					<default>false</default>
 					<control type="toggle" />
 				</setting>
+			</group>
+			<group id="authentication" label="32011">
 				<setting id="username" type="string" label="32001" help="">
 					<level>0</level>
 					<default />


### PR DESCRIPTION
The add-on depends on inputstream.adaptive (declared in addon.xml) but never activates it. play_video only sets the URL + mimetype, so Kodi falls back to its internal ffmpeg HLS demuxer. This change sets inputstream to inputstream.adaptive on the playabe ListItem so the HLS stream is handled by ISA.

I'm running Kodi on a pretty bizarrely configured RK3588 based platform, but the consequence of inputstream.adaptive not being toggled was that the video stream ended up not getting hardware acceleration.

Take this PR with a grain of salt, good ol' Claude helped be debug the issue and I'm not very familiar with Kodi. That being said, this worked for me and ensured that the hardware decoder was used to play the stream.