### PR TITLE
fix(dropout): add timeouts to all network requests

### DIFF
--- a/plugin.video.dropout/addon.xml
+++ b/plugin.video.dropout/addon.xml
@@ -3,7 +3,7 @@
   id="plugin.video.dropout"
   name="Dropout.tv"
   provider-name="LouisBrunner"
-  version="0.1.0"
+  version="0.1.1"
 >
 	<requires>
 		<import addon="xbmc.python" version="3.0.1" />
@@ -28,7 +28,10 @@ Subscription required.</description>
 		<language>en</language>
 		<website />
 		<source>https://github.com/LouisBrunner/kodi-addons</source>
-		<news>v0.1.0 (2026-06-12)
+		<news>v0.1.1 (2026-06-24)
+- Add timeouts to all network requests to prevent indefinite hangs
+
+v0.1.0 (2026-06-12)
 - Proper support for inputstream.adaptive, which is now fully optional (#70)
 
 v0.0.5 (2025-12-10)

--- a/plugin.video.dropout/resources/lib/api.py
+++ b/plugin.video.dropout/resources/lib/api.py
@@ -14,6 +14,8 @@ from .addon import Addon
 from .config import Credentials, PlayState
 from .utils import LOGDEBUG, LOGERROR, LOGNONE, LOGWARNING, log_message
 
+REQUEST_TIMEOUT_S = (10, 30)
+
 TOKEN_FINDER = r'(?s)window\.VHX\.config\s*=\s*{.*token:\s*"([^"]*)",'
 USER_FINDER = r'_current_user":{"id":([^,]+),"'
 EMBED_FINDER = r'(?s)window\.VHX\.config\s*=\s*{.*embed_url:\s*"([^"]*)",'
@@ -355,7 +357,7 @@ class API:
             level=LOGNONE,
         )
         rep = self.__session.request(
-            method, "".join([self.WEBSITE_URL, url]), data=data
+            method, "".join([self.WEBSITE_URL, url]), data=data, timeout=REQUEST_TIMEOUT_S
         )
         Addon.CONFIG.set_cookie_jar(
             requests.utils.dict_from_cookiejar(self.__session.cookies)
@@ -607,6 +609,7 @@ class API:
             headers={
                 "Authorization": f"Bearer {self.__token}",
             },
+            timeout=REQUEST_TIMEOUT_S,
         )
         if not res.ok:
             msg = f"api request to {url} ({next_url}) failed with {res.status_code} and {res.text}"
@@ -648,6 +651,7 @@ class API:
                 headers={
                     "Authorization": f"Bearer {self.__token}",
                 },
+                timeout=REQUEST_TIMEOUT_S,
             )
             if not res.ok:
                 msg = f"api request pages to {url} ({next_url}) failed with {res.status_code} and {res.text}"
@@ -1174,6 +1178,7 @@ class API:
             headers={
                 "Referer": self.REFERER_URL,
             },
+            timeout=REQUEST_TIMEOUT_S,
         )
         config_info = re.search(CONFIG_FINDER, embed_page.text)
         if config_info is None:
@@ -1181,7 +1186,7 @@ class API:
                 f"could not find config url in {url} ({embed_page}/{embed_page.text})",
             )
         config_url = json.loads(config_info.group(1))["config_url"]
-        return requests.get(config_url).json()
+        return requests.get(config_url, timeout=REQUEST_TIMEOUT_S).json()
 
     def playable_from_id(self, id: int) -> Tuple[Playable, VideoData]:
         video_res = self.__get_video_by_id(id)

--- a/plugin.video.dropout/resources/lib/api.py
+++ b/plugin.video.dropout/resources/lib/api.py
@@ -357,7 +357,10 @@ class API:
             level=LOGNONE,
         )
         rep = self.__session.request(
-            method, "".join([self.WEBSITE_URL, url]), data=data, timeout=REQUEST_TIMEOUT_S
+            method,
+            "".join([self.WEBSITE_URL, url]),
+            data=data,
+            timeout=REQUEST_TIMEOUT_S,
         )
         Addon.CONFIG.set_cookie_jar(
             requests.utils.dict_from_cookiejar(self.__session.cookies)
@@ -420,10 +423,12 @@ class API:
         log_message(f"continue watching [FROM API]: {res}", level=LOGDEBUG)
         res.items = list(
             filter(
-                lambda i: not isinstance(i, ReleasedVideo)
-                or i.play_state is None
-                or not i.play_state.completed
-                or not i.play_state.from_us,
+                lambda i: (
+                    not isinstance(i, ReleasedVideo)
+                    or i.play_state is None
+                    or not i.play_state.completed
+                    or not i.play_state.from_us
+                ),
                 res.items,
             )
         )


### PR DESCRIPTION
Add `timeout=(10, 30)` to all 5 `requests` calls in `api.py` (10s connect, 30s read). Fixes indefinite hangs on "Loading ...".

Bumps to v0.1.1.